### PR TITLE
Improved user handling to work better with centos7 role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Role Name
+OULibraries.ec2-init
 =========
 
 OULibraries EC2 init.
@@ -10,6 +10,20 @@ Uses the EC2 module, so the boto package is required.
 
 Role Variables
 --------------
+You'll need to define one or more users in the 'users' var. eg.
+
+```
+users:
+  - name: 'centos'
+    groups: [centos, wheel]
+    keyname: 'aws-name-for-key'
+    pubkey: 'ssh-rsa somepubkey centos@example.org'
+  - name: 'centos1'
+    groups: 'wheel'
+    pubkey: 'ssh-rsa anotherpubkey centos@example.org'
+```
+
+the specified key will be added to aws if it isn't already there.
 
 ec2_vpc_subnet_id: The VPC subnet to which you wish to deploy this machine
 ec2_key_name: The keypair name as listed in your aws console

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 ec2_instance_profile_name: "lib-amz-default"
-ec2_instance_default_user_name: "centos"
 ec2_image: "ami-6d1c2007"
 ec2_tag_Name: "lib-amz-default-version_branch"
 ec2_tag_App: "Default"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,28 @@
 ---
+- name: Set instance default user and key to 1st user in vars
+  set_fact:
+    ec2_instance_default_user_name: "{{ item.1.name }}"
+    ec2_key_name: "{{ item.1.keyname }}"
+    ec2_key_material: "{{ item.1.pubkey }}"
+  with_indexed_items: "{{ users }}"
+  when: item.0 == 0
+- name: ec2 key
+  ec2_key:
+    name: "{{ hostvars['localhost']['ec2_key_name'] }}"
+    key_material: "{{ hostvars['localhost']['ec2_key_material'] }}"
+    region: us-east-1
+    state: present
 - name: Launch instance
   ec2:
-    key_name: "{{ ec2_key_name }}"
+    key_name: "{{ hostvars['localhost']['ec2_key_name'] }}"
     instance_type: "{{ ec2_instance_type }}"
     image: "{{ ec2_image }}"
     instance_profile_name: "{{ ec2_instance_profile_name }}"
     user_data: |
       #cloud-config
-      users:
-        - name: "{{ item.name }}"
-          groups: "{{ item.groups }}"
-          ssh-authorized-keys: "{{ item.pubkey }}"
+      system_info:
+        default_user:
+          name: "{{ hostvars['localhost']['ec2_instance_default_user_name'] }}"
     wait: yes
     group: ['Outbound Open', 'Inbound ssh lib-amz-broker']
     instance_tags:
@@ -30,7 +42,6 @@
       device_type: gp2
       volume_size: "{{ ec2_volume_size }}"
       delete_on_termination: true
-  with_items: "{{ users }}"
   register: ec2
 - name: Wait 3 minutes
   wait_for: timeout=180

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,10 +7,10 @@
     instance_profile_name: "{{ ec2_instance_profile_name }}"
     user_data: |
       #cloud-config
-      system_info:
-        default_user:
-          name: "{{ ec2_instance_default_user_name }}"
-          sudo: ALL=(ALL) NOPASSWD:ALL
+      users:
+        - name: "{{ item.name }}"
+          groups: "{{ item.groups }}"
+          ssh-authorized-keys: "{{ item.pubkey }}"
     wait: yes
     group: ['Outbound Open', 'Inbound ssh lib-amz-broker']
     instance_tags:
@@ -30,6 +30,7 @@
       device_type: gp2
       volume_size: "{{ ec2_volume_size }}"
       delete_on_termination: true
+  with_items: "{{ users }}"
   register: ec2
 - name: Wait 3 minutes
   wait_for: timeout=180


### PR DESCRIPTION
use generic user vars and drop ec2-specific user vars where possible.
## Motivation and Context

Users should only have to specify their desired users once. Since ec2 init and centos7 roles currently have different user provisioning data structures, users must specify repeated user info that has to match.
https://github.com/OULibraries/ansible-role-ec2-init/issues/3
## How Has This Been Tested?

a bunch of ec2 inits
