### PR TITLE
Name-based hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ OULibraries EC2 init.
 Requirements
 ------------
 
-Uses the EC2 module, so the boto package is required.
+Uses the EC2 module, so the boto package is required. Now requires Ansible 2.x
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -10,23 +10,23 @@ Uses the EC2 module, so the boto package is required.
 
 Role Variables
 --------------
-You'll need to define one or more users in the 'users' var. eg.
+You'll need to define at least one user in the 'users' var. eg.
 
 ```
 users:
   - name: 'centos'
-    groups: [centos, wheel]
+    groups: [wheel]
     keyname: 'aws-name-for-key'
     pubkey: 'ssh-rsa somepubkey centos@example.org'
-  - name: 'centos1'
-    groups: 'wheel'
-    pubkey: 'ssh-rsa anotherpubkey centos@example.org'
 ```
 
-the specified key will be added to aws if it isn't already there.
+The first user and key listed will be used to launch the instance. The first user's key key will be added to aws if it isn't already there.
 
-ec2_vpc_subnet_id: The VPC subnet to which you wish to deploy this machine
-ec2_key_name: The keypair name as listed in your aws console
+ec2_tag_name should be the internal dns name of your instance. Note that this means that you either need to implement your own dns in aws, or you'll need to wrangle hosts files. eg.
+
+```
+ec2_tag_Name: "app.workload.department.ec2.internal"
+```
 
 For the rest, see defaults/main.yml
 
@@ -52,4 +52,4 @@ TBD
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+Jason Sherman

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ec2_instance_profile_name: "lib-amz-default"
 ec2_image: "ami-6d1c2007"
-ec2_tag_Name: "lib-amz-default-version_branch"
+ec2_tag_Name: "app.workload.department.ec2.internal"
 ec2_tag_App: "Default"
 ec2_tag_Unit: "Default"
 ec2_tag_Workload: "Unprovisioned"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ec2_instance_profile_name: "lib-amz-default"
 ec2_image: "ami-6d1c2007"
+ec2_region: "us-east-1"
 ec2_tag_Name: "app.workload.department.ec2.internal"
 ec2_tag_App: "Default"
 ec2_tag_Unit: "Default"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
 - name: Wait 3 minutes
   wait_for: timeout=180
   when: ec2.changed == True
-  - name: Add instance to host group
+- name: Add instance to host group
   add_host: hostname={{ ec2_tag_Name }}
     groupname=ec2.unprovisioned
   when: ec2.changed == True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,8 +32,7 @@
       App: "{{ ec2_tag_App }}"
     exact_count: "{{ ec2_exact_count }}"
     count_tag:
-      App: "{{ ec2_tag_App }}"
-      Workload: "{{ ec2_tag_Workload }}"
+      App: "{{ ec2_tag_Name }}"
     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
     assign_public_ip: yes
     region: us-east-1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,8 @@
     key_material: "{{ hostvars['localhost']['ec2_key_material'] }}"
     region: us-east-1
     state: present
+- name: refresh inventory
+  meta: refresh_inventory
 - name: Launch instance
   ec2:
     key_name: "{{ hostvars['localhost']['ec2_key_name'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,17 @@
     key_material: "{{ hostvars['localhost']['ec2_key_material'] }}"
     region: us-east-1
     state: present
+- name: Check for unprovisioned instances
+  ec2_remote_facts:
+    region: 'us-east-1'
+    filters:
+      instance-state-name: running
+      subnet-id: "{{ ec2_vpc_subnet_id }}"
+      "tag:Name": "{{ ec2_tag_Name }}"
+      "tag:Unit": "{{ ec2_tag_Unit }}"
+      "tag:Workload": Unprovisioned
+      "tag:App": "{{ ec2_tag_App }}"
+  register: ec2_pre_info
 - name: Launch instance
   ec2:
     key_name: "{{ hostvars['localhost']['ec2_key_name'] }}"
@@ -32,7 +43,7 @@
       App: "{{ ec2_tag_App }}"
     exact_count: "{{ ec2_exact_count }}"
     count_tag:
-      App: "{{ ec2_tag_Name }}"
+      Name: "{{ ec2_tag_Name }}"
     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
     assign_public_ip: yes
     region: us-east-1
@@ -42,6 +53,7 @@
       volume_size: "{{ ec2_volume_size }}"
       delete_on_termination: true
   register: ec2
+  when: not ec2_pre_info.instances
 - name: Wait 3 minutes
   wait_for: timeout=180
   when: ec2.changed == True
@@ -59,7 +71,7 @@
       "tag:Unit": "{{ ec2_tag_Unit }}"
       "tag:Workload": Unprovisioned
       "tag:App": "{{ ec2_tag_App }}"
-  register: ec2_info
+  register: ec2_post_info
 - name: Set Name, intended workload, private_ip, region, and ID as fact
   set_fact:
     server_tag_name: "{{ ec2_tag_Name }}"
@@ -67,4 +79,4 @@
     instance_id: "{{ item.id }}"
     server_ip: "{{ item.private_ip_address }}"
     region: "{{ item.region }}"
-  with_items: "{{ ec2_info.instances }}"
+  with_items: "{{ ec2_post_info.instances }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
     state: present
 - name: Check for unprovisioned instances
   ec2_remote_facts:
-    region: 'us-east-1'
+    region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
       subnet-id: "{{ ec2_vpc_subnet_id }}"
@@ -63,7 +63,7 @@
   when: ec2.changed == True
 - name: Gather ec2 facts
   ec2_remote_facts:
-    region: 'us-east-1'
+    region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
       subnet-id: "{{ ec2_vpc_subnet_id }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,8 +12,6 @@
     key_material: "{{ hostvars['localhost']['ec2_key_material'] }}"
     region: us-east-1
     state: present
-- name: refresh inventory
-  meta: refresh_inventory
 - name: Launch instance
   ec2:
     key_name: "{{ hostvars['localhost']['ec2_key_name'] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,13 +47,13 @@
   wait_for: timeout=180
   when: ec2.changed == True
 - name: Add instance to host group
-  add_host: hostname={{ item.private_ip }} groupname=unprovisioned
-  with_items: ec2.instances
+  add_host: hostname={{ ec2_tag_Name }} groupname=ec2.unprovisioned
   when: ec2.changed == True
-- name: Set Name, intended workload, region, and ID as fact
+- name: Set Name, intended workload, private_ip, region, and ID as fact
   set_fact:
     server_tag_name: "{{ ec2_tag_Name }}"
     server_tag_workload: "{{ ec2_tag_Workload }}"
     instance_id: "{{ item.id }}"
+    server_private_ip: "{{ item.private_ip }}"
     region: "{{ item.region }}"
   with_items: "{{ ec2.tagged_instances }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,6 @@
     server_tag_name: "{{ ec2_tag_Name }}"
     server_tag_workload: "{{ ec2_tag_Workload }}"
     instance_id: "{{ item.id }}"
-    server_private_ip: "{{ item.private_ip }}"
+    server_ip: "{{ item.private_ip }}"
     region: "{{ item.region }}"
   with_items: "{{ ec2.tagged_instances }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,14 +47,26 @@
 - name: Wait 3 minutes
   wait_for: timeout=180
   when: ec2.changed == True
-- name: Add instance to host group
-  add_host: hostname={{ ec2_tag_Name }} groupname=ec2.unprovisioned
+  - name: Add instance to host group
+  add_host: hostname={{ ec2_tag_Name }}
+    groupname=ec2.unprovisioned
   when: ec2.changed == True
+- name: Gather ec2 facts
+  ec2_remote_facts:
+    region: 'us-east-1'
+    filters:
+      instance-state-name: running
+      subnet-id: "{{ ec2_vpc_subnet_id }}"
+      "tag:Name": "{{ ec2_tag_Name }}"
+      "tag:Unit": "{{ ec2_tag_Unit }}"
+      "tag:Workload": Unprovisioned
+      "tag:App": "{{ ec2_tag_App }}"
+  register: ec2_info
 - name: Set Name, intended workload, private_ip, region, and ID as fact
   set_fact:
     server_tag_name: "{{ ec2_tag_Name }}"
     server_tag_workload: "{{ ec2_tag_Workload }}"
     instance_id: "{{ item.id }}"
-    server_ip: "{{ item.private_ip }}"
+    server_ip: "{{ item.private_ip_address }}"
     region: "{{ item.region }}"
-  with_items: "{{ ec2.tagged_instances }}"
+  with_items: "{{ ec2_info.instances }}"


### PR DESCRIPTION
I'm moving our inventory to use names instead of IP addresses, this means we need to tweak things slightly.
## Motivation and Context

Moving to names instead of IP addresses will allow us to greatly reduce the amount of client-side ssh config required to deal with things via ansible.
## How Has This Been Tested?

a whole bunch of ec2-initing
