### PR TITLE
manage multi region deployments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-ec2_default_instance_profile_name: "lib-amz-default"
+
+ec2_default_instance_profile_name: "default"
 
 ec2_default_image: "ami-6d1c2007"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,19 +1,52 @@
 ---
 ec2_default_instance_profile_name: "lib-amz-default"
+
 ec2_default_image: "ami-6d1c2007"
-ec2_default_region: "us-east-1"
+
 ec2_default_instance_type: "t2.medium"
+
 ec2_default_exact_count: 1
+
+ec2_default_user_data: |
+  #cloud-config
+  system_info:
+    default_user:
+      name: "{{ hostvars['localhost']['ec2_instance_default_user_name'] }}"
+
 ec2_default_volumes:
   - device_name: /dev/sda1
     device_type: gp2
     volume_size: 64
     delete_on_termination: true
 
-ec2_instances:
-  - ec2_tag_Name: app.dev.department.ec2.internal
-    ec2_tag_Environment: Development
-    ec2_tag_Product: Default
-    ec2_tag_Role: Default
-    ec2_tag_Unit: Default
-    ec2_security_group: ['out_all', 'in_ssh_broker']
+aws_us_east_1: !!null
+#  - vpc: !!null
+#      subnet: !!null
+#      instances:
+#        - name: !!null
+#          type: "t2.micro"
+#          image: ami-6a2d760f
+#          environment: Development
+#          product: Default
+#          role: Default
+#          unit: Default
+#          security_group: ['linux_default']
+#          security_groups:
+#            - name: donotuse_example
+#              description: "Do not use. Allow all outbound traffic, all inbound ping, and all inbound ssh"
+#              rules:
+#                - proto: icmp
+#                  from_port: 8
+#                  to_port: 8
+#                  cidr_ip: 0.0.0.0/0
+#                - proto: tcp
+#                  from_port: 22
+#                  to_port: 22
+#                  cidr_ip: 0.0.0.0/0
+#              rules_egress:
+#                - proto: all
+#                  from_port: 0
+#                  to_port: 65535
+#                  cidr_ip: 0.0.0.0/0
+
+aws_us_east_2: !!null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,12 +13,10 @@
 
 - include: us-east-1.yml
   when: ((aws_us_east_1 is defined) and (aws_us_east_1 is not none))
-  become: true
   tags:
   - ec2-init_us_east_1
 
 - include: us-east-2.yml
   when: ((aws_us_east_2 is defined) and (aws_us_east_2 is not none))
-  become: true
   tags:
   - ec2-init_us_east_2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,11 +12,13 @@
   - ec2-init_ssh_key
 
 - include: us-east-1.yml
+  static: no
   when: ((aws_us_east_1 is defined) and (aws_us_east_1 is not none))
   tags:
   - ec2-init_us_east_1
 
 - include: us-east-2.yml
+  static: no
   when: ((aws_us_east_2 is defined) and (aws_us_east_2 is not none))
   tags:
   - ec2-init_us_east_2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,79 +1,13 @@
 ---
-- name: Set instance default user and key to 1st user in vars
-  set_fact:
-    ec2_instance_default_user_name: "{{ item.1.name }}"
-    ec2_key_name: "{{ item.1.keyname }}"
-    ec2_key_material: "{{ item.1.pubkey }}"
-  when: (item.0 == 0)
-  with_indexed_items:
-    - "{{ users }}"
 
-- name: ec2 key
-  ec2_key:
-    name: "{{ hostvars['localhost']['ec2_key_name'] }}"
-    key_material: "{{ hostvars['localhost']['ec2_key_material'] }}"
-    region: "{{ ec2_default_region }}"
-    state: present
+- include: us-east-1.yml
+  when: ((aws_us_east_1 is defined) and (aws_us_east_1 is not none))
+  become: true
+  tags:
+  - ec2-init_us_east_1
 
-- name: Configure EC2 Security Groups.
-  ec2_group:
-    name: "{{ item.name }}"
-    description: "{{ item.description }}"
-    region: "{{ ec2_default_region }}"
-    vpc_id: "{{ ec2_default_vpc_id }}"
-    state: present
-    rules: "{{ item.rules }}"
-    rules_egress: "{{ item.rules_egress }}"
-  with_items: "{{ ec2_security_groups }}"
-
-- name: Launch instance
-  ec2:
-    key_name: "{{ hostvars['localhost']['ec2_key_name'] }}"
-    instance_type: "{{ item.ec2_instance_type }}"
-    private_ip: "{{ item.ec2_private_ip | default(omit) }}"
-    image: "{{ item.ec2_image | default(ec2_default_image) }}"
-    instance_profile_name: "{{ item.ec2_instance_profile_name | default(ec2_default_instance_profile_name) }}"
-    user_data: "{{ item.ec2_user_data }}"
-    wait: yes
-    group: "{{ item.ec2_security_group }}"
-    instance_tags:
-      Name: "{{ item.ec2_tag_Name }}"
-      Environment: "{{ item.ec2_tag_Environment }}"
-      Product: "{{ item.ec2_tag_Product }}"
-      Role: "{{ item.ec2_tag_Role }}"
-      Unit: "{{ item.ec2_tag_Unit }}"
-      State: Unprovisioned
-    exact_count: "{{ item.ec2_exact_count | default(ec2_default_exact_count) }}"
-    count_tag:
-      Name: "{{ item.ec2_tag_Name }}"
-    vpc_subnet_id: "{{ item.ec2_vpc_subnet_id | default(ec2_default_vpc_subnet_id) }}"
-    assign_public_ip: yes
-    region: "{{ item.ec2_region | default(ec2_default_region) }}"
-    volumes: "{{ item.ec2_volumes | default(ec2_default_volumes) }}"
-  register: ec2
-  with_items: "{{ ec2_instances }}"
-
-- name: Wait 3 minutes
-  wait_for: timeout=180
-  when: ec2.changed == True
-
-- name: Gather ec2 facts
-  ec2_remote_facts:
-    region: "{{ ec2_default_region }}"
-    filters:
-      instance-state-name: running
-      subnet-id: "{{ ec2_default_vpc_subnet_id }}"
-      "tag:State": Unprovisioned
-  register: ec2_post_info
-
-- name: Add unprovisioned instances to host group
-  add_host:
-    hostname: "{{ item.tags.Name }}"
-    groupname: "ec2.unprovisioned"
-  when: (item.tags.State == "Unprovisioned")
-  with_items: "{{ ec2_post_info.instances }}"
-
-- name: Set as local fact
-  set_fact:
-    ec2_post_info: "{{ ec2_post_info }}"
-  when: ((ec2_post_info is defined) and (ec2_post_info is not none))
+- include: us-east-2.yml
+  when: ((aws_us_east_2 is defined) and (aws_us_east_2 is not none))
+  become: true
+  tags:
+  - ec2-init_us_east_2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,16 @@
 ---
 
+- name: Set instance default user and key to 1st user in vars
+  set_fact:
+    ec2_instance_default_user_name: "{{ item.1.name }}"
+    ec2_key_name: "{{ item.1.keyname }}"
+    ec2_key_material: "{{ item.1.pubkey }}"
+  when: (item.0 == 0)
+  with_indexed_items:
+    - "{{ users }}"
+  tags:
+  - ec2-init_ssh_key
+
 - include: us-east-1.yml
   when: ((aws_us_east_1 is defined) and (aws_us_east_1 is not none))
   become: true

--- a/tasks/us-east-1.yml
+++ b/tasks/us-east-1.yml
@@ -60,13 +60,6 @@
   with_items:
     - "{{ aws_us_east_1 }}"
 
-- debug:
-    msg: >
-      {{ item.1.tags.Name }}
-  with_subelements:
-    - "{{ ec2_post_info.results }}"
-    - instances
-
 - name: Add unprovisioned instances to host group
   add_host:
     hostname: "{{ item.1.tags.Name }}"

--- a/tasks/us-east-1.yml
+++ b/tasks/us-east-1.yml
@@ -78,5 +78,5 @@
 
 - name: Set as local fact
   set_fact:
-    ec2_post_info: "{{ ec2_post_info.results }}"
+    ec2_post_info_accumulator: "{{ ec2_post_info_accumulator | default([]) }} + {{ ec2_post_info.results }}"
   when: ((ec2_post_info.results is defined) and (ec2_post_info.results is not none))

--- a/tasks/us-east-1.yml
+++ b/tasks/us-east-1.yml
@@ -23,7 +23,7 @@
 - name: Ensure US-East-1 instances
   ec2:
     key_name: "{{ hostvars['localhost']['ec2_key_name'] }}"
-    instance_type: "{{ item.1.type }}"
+    instance_type: "{{ item.1.type | default(ec2_default_instance_type) }}"
     private_ip: "{{ item.1.private_ip | default(omit) }}"
     image: "{{ item.1.image | default(ec2_default_image) }}"
     instance_profile_name: "{{ item.1.profile_name | default(ec2_default_instance_profile_name) }}"

--- a/tasks/us-east-1.yml
+++ b/tasks/us-east-1.yml
@@ -1,0 +1,82 @@
+---
+
+- name: ec2 key
+  ec2_key:
+    name: "{{ hostvars['localhost']['ec2_key_name'] }}"
+    key_material: "{{ hostvars['localhost']['ec2_key_material'] }}"
+    region: us-east-1
+    state: present
+
+- name: Ensure US-East-1 Security Groups.
+  ec2_group:
+    name: "{{ item.1.name }}"
+    description: "{{ item.1.description }}"
+    region: us-east-1
+    vpc_id: "{{ item.0.vpc }}"
+    state: present
+    rules: "{{ item.1.rules }}"
+    rules_egress: "{{ item.1.rules_egress }}"
+  with_subelements:
+    - "{{ aws_us_east_1 }}"
+    - security_groups
+
+- name: Ensure US-East-1 instances
+  ec2:
+    key_name: "{{ hostvars['localhost']['ec2_key_name'] }}"
+    instance_type: "{{ item.1.type }}"
+    private_ip: "{{ item.1.private_ip | default(omit) }}"
+    image: "{{ item.1.image | default(ec2_default_image) }}"
+    instance_profile_name: "{{ item.1.profile_name | default(ec2_default_instance_profile_name) }}"
+    user_data: "{{ item.1.user_data | default(ec2_default_user_data) }}"
+    wait: yes
+    group: "{{ item.1.security_group }}"
+    instance_tags:
+      Name: "{{ item.1.name }}"
+      Environment: "{{ item.1.environment }}"
+      Product: "{{ item.1.product }}"
+      Role: "{{ item.1.role }}"
+      Unit: "{{ item.1.unit }}"
+      State: Unprovisioned
+    exact_count: "{{ item.1.exact_count | default(ec2_default_exact_count) }}"
+    count_tag:
+      Name: "{{ item.1.name }}"
+    vpc_subnet_id: "{{ item.0.subnet | default(ec2_default_vpc_subnet_id) }}"
+    assign_public_ip: yes
+    region: us-east-1
+    volumes: "{{ item.1.ec2_volumes | default(ec2_default_volumes) }}"
+  register: ec2
+  with_subelements:
+    - "{{ aws_us_east_1 }}"
+    - instances
+
+- name: Gather US-East-1 facts
+  ec2_remote_facts:
+    region: us-east-1
+    filters:
+      instance-state-name: running
+      subnet-id: "{{ item.subnet }}"
+      "tag:State": Unprovisioned
+  register: ec2_post_info
+  with_items:
+    - "{{ aws_us_east_1 }}"
+
+- debug:
+    msg: >
+      {{ item.1.tags.Name }}
+  with_subelements:
+    - "{{ ec2_post_info.results }}"
+    - instances
+
+- name: Add unprovisioned instances to host group
+  add_host:
+    hostname: "{{ item.1.tags.Name }}"
+    groupname: "ec2.unprovisioned"
+  when: (item.1.tags.State == "Unprovisioned")
+  with_subelements:
+    - "{{ ec2_post_info.results }}"
+    - instances
+
+- name: Set as local fact
+  set_fact:
+    ec2_post_info: "{{ ec2_post_info.results }}"
+  when: ((ec2_post_info.results is defined) and (ec2_post_info.results is not none))

--- a/tasks/us-east-2.yml
+++ b/tasks/us-east-2.yml
@@ -23,7 +23,7 @@
 - name: Ensure US-East-2 instances
   ec2:
     key_name: "{{ hostvars['localhost']['ec2_key_name'] }}"
-    instance_type: "{{ item.1.type }}"
+    instance_type: "{{ item.1.type | default(ec2_default_instance_type) }}"
     private_ip: "{{ item.1.private_ip | default(omit) }}"
     image: "{{ item.1.image | default(ec2_default_image) }}"
     instance_profile_name: "{{ item.1.profile_name | default(ec2_default_instance_profile_name) }}"

--- a/tasks/us-east-2.yml
+++ b/tasks/us-east-2.yml
@@ -60,13 +60,6 @@
   with_items:
     - "{{ aws_us_east_2 }}"
 
-- debug:
-    msg: >
-      {{ item.1.tags.Name }}
-  with_subelements:
-    - "{{ ec2_post_info.results }}"
-    - instances
-
 - name: Add unprovisioned instances to host group
   add_host:
     hostname: "{{ item.1.tags.Name }}"

--- a/tasks/us-east-2.yml
+++ b/tasks/us-east-2.yml
@@ -78,5 +78,5 @@
 
 - name: Set as local fact
   set_fact:
-    ec2_post_info: "{{ ec2_post_info.results }}"
+    ec2_post_info_accumulator: "{{ ec2_post_info_accumulator | default([]) }} + {{ ec2_post_info.results }}"
   when: ((ec2_post_info.results is defined) and (ec2_post_info.results is not none))

--- a/tasks/us-east-2.yml
+++ b/tasks/us-east-2.yml
@@ -1,0 +1,82 @@
+---
+
+- name: ec2 key
+  ec2_key:
+    name: "{{ hostvars['localhost']['ec2_key_name'] }}"
+    key_material: "{{ hostvars['localhost']['ec2_key_material'] }}"
+    region: us-east-2
+    state: present
+
+- name: Ensure US-East-2 Security Groups.
+  ec2_group:
+    name: "{{ item.1.name }}"
+    description: "{{ item.1.description }}"
+    region: us-east-2
+    vpc_id: "{{ item.0.vpc }}"
+    state: present
+    rules: "{{ item.1.rules }}"
+    rules_egress: "{{ item.1.rules_egress }}"
+  with_subelements:
+    - "{{ aws_us_east_2 }}"
+    - security_groups
+
+- name: Ensure US-East-2 instances
+  ec2:
+    key_name: "{{ hostvars['localhost']['ec2_key_name'] }}"
+    instance_type: "{{ item.1.type }}"
+    private_ip: "{{ item.1.private_ip | default(omit) }}"
+    image: "{{ item.1.image | default(ec2_default_image) }}"
+    instance_profile_name: "{{ item.1.profile_name | default(ec2_default_instance_profile_name) }}"
+    user_data: "{{ item.1.user_data | default(ec2_default_user_data) }}"
+    wait: yes
+    group: "{{ item.1.security_group }}"
+    instance_tags:
+      Name: "{{ item.1.name }}"
+      Environment: "{{ item.1.environment }}"
+      Product: "{{ item.1.product }}"
+      Role: "{{ item.1.role }}"
+      Unit: "{{ item.1.unit }}"
+      State: Unprovisioned
+    exact_count: "{{ item.1.exact_count | default(ec2_default_exact_count) }}"
+    count_tag:
+      Name: "{{ item.1.name }}"
+    vpc_subnet_id: "{{ item.0.subnet | default(ec2_default_vpc_subnet_id) }}"
+    assign_public_ip: yes
+    region: us-east-2
+    volumes: "{{ item.1.ec2_volumes | default(ec2_default_volumes) }}"
+  register: ec2
+  with_subelements:
+    - "{{ aws_us_east_2 }}"
+    - instances
+
+- name: Gather US-East-2 facts
+  ec2_remote_facts:
+    region: us-east-2
+    filters:
+      instance-state-name: running
+      subnet-id: "{{ item.subnet }}"
+      "tag:State": Unprovisioned
+  register: ec2_post_info
+  with_items:
+    - "{{ aws_us_east_2 }}"
+
+- debug:
+    msg: >
+      {{ item.1.tags.Name }}
+  with_subelements:
+    - "{{ ec2_post_info.results }}"
+    - instances
+
+- name: Add unprovisioned instances to host group
+  add_host:
+    hostname: "{{ item.1.tags.Name }}"
+    groupname: "ec2.unprovisioned"
+  when: (item.1.tags.State == "Unprovisioned")
+  with_subelements:
+    - "{{ ec2_post_info.results }}"
+    - instances
+
+- name: Set as local fact
+  set_fact:
+    ec2_post_info: "{{ ec2_post_info.results }}"
+  when: ((ec2_post_info.results is defined) and (ec2_post_info.results is not none))


### PR DESCRIPTION
Make the deployer less dumb about initing things across regions.

Motivation and Context
----------------------
I previously had to comment out everything not in the region I was deploying to.  This was pretty dumb.

How Has This Been Tested?
-------------------------
I deployed things in us-east-1 and us-east-2 and we're all still here.
